### PR TITLE
Remove reply queue on timeout

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -76,6 +76,7 @@ function request (connection, queueName, content, opts, cb) {
       opts: opts
     }
     var corrId = uuid()
+    var replyQueue = queueName + '-reply-' + corrId
     // channel close promise
     var channelClosePromise = first(channel, ['close'])
     var cancel = channelClosePromise.cancel // cache cancel
@@ -85,7 +86,7 @@ function request (connection, queueName, content, opts, cb) {
     })
     channelClosePromise.cancel = cancel // restore cancel
     debug('Assert queue and send request', corrId, queueOpts)
-    var assertAndSendPromise = channel.assertQueue('', queueOpts).then(function (replyQueue) {
+    var assertAndSendPromise = channel.assertQueue(replyQueue, queueOpts).then(function (replyQueue) {
       debug('Assert queue and send request: success', corrId, replyQueue)
       // rpc correlation id
       // rpc response message promise
@@ -140,6 +141,8 @@ function request (connection, queueName, content, opts, cb) {
       debug('Add timeout promise')
       promises.push(
         timeout(opts.timeout).then(function () {
+          channel.deleteQueue(replyQueue);
+
           // throw timeout error
           throw new TimeoutError('rpc timed out', {
             queue: queueName,


### PR DESCRIPTION
It would be great to remove reply queue after timeout error.
@tjmehta What do you think maybe we can remove reply queue once at the end of request function?