### PR TITLE
Allow other exchanges than default

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -45,17 +45,20 @@ function request (connection, queueName, content, opts, cb) {
     args.opts.timeout,
     args.opts.sendOpts,
     args.opts.queueOpts,
-    args.opts.consumeOpts
+    args.opts.consumeOpts,
+    args.opts.exchangeName
   ], {
     '[opts.timeout]': ['number'],
     '[opts.sendOpts]': 'object',
     '[opts.queueOpts]': 'object',
-    '[opts.consumeOpts]': 'object'
+    '[opts.consumeOpts]': 'object',
+    '[opts.exchangeName]': 'string'
   })
   defaults(args.opts, {
     sendOpts: {},
     queueOpts: {},
-    consumeOpts: {}
+    consumeOpts: {},
+    exchangeName: ''
   })
   queueName = args.queueName
   content = castBuffer(args.content)
@@ -67,6 +70,7 @@ function request (connection, queueName, content, opts, cb) {
   var sendOpts = opts.sendOpts
   var queueOpts = opts.queueOpts
   var consumeOpts = opts.consumeOpts
+  var exchangeName = opts.exchangeName
 
   debug('createChannel')
   var promise = connection.createChannel().then(function (channel) {
@@ -113,7 +117,7 @@ function request (connection, queueName, content, opts, cb) {
         replyTo: replyQueue.queue
       })
       debug('Send request message:', corrId, queueName, content, _sendOpts)
-      channel.sendToQueue(queueName, content, _sendOpts)
+      channel.publish(exchangeName, queueName, content, _sendOpts)
       // return response promise
       return responsePromise
         .catch(function (err) {

--- a/test/request.unit.js
+++ b/test/request.unit.js
@@ -45,7 +45,7 @@ describe('request', function () {
     sinon.stub(ctx.channel, 'assertQueue')
     sinon.stub(ctx.channel, 'consume')
     sinon.stub(ctx.channel, 'deleteQueue')
-    sinon.stub(ctx.channel, 'sendToQueue')
+    sinon.stub(ctx.channel, 'publish')
     sinon.stub(ctx.channel, 'close')
     // queue args
     ctx.rpcQueueName = 'rpc-queue'
@@ -138,13 +138,13 @@ describe('request', function () {
           sinon.assert.calledOnce(ctx.channel.consume)
           sinon.assert.calledWith(ctx.channel.consume,
             ctx.replyQueue.queue, sinon.match.func, put(ctx.opts.consumeOpts, { noAck: true }))
-          sinon.assert.calledOnce(ctx.channel.sendToQueue)
+          sinon.assert.calledOnce(ctx.channel.publish)
           var expectedSendOpts = put(ctx.opts.sendOpts, {
             correlationId: ctx.corrId,
             replyTo: ctx.replyQueue.queue
           })
-          sinon.assert.calledWith(ctx.channel.sendToQueue,
-            ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
+          sinon.assert.calledWith(ctx.channel.publish,
+            '', ctx.rpcQueueName, bufferMatch(ctx.bufferContent), expectedSendOpts)
           sinon.assert.calledOnce(ctx.channel.close)
           done()
         })
@@ -216,7 +216,8 @@ describe('request', function () {
                 opts: {
                   sendOpts: ctx.opts.sendOpts,
                   queueOpts: put(ctx.opts.queueOpts, {exclusive: true}),
-                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true})
+                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true}),
+                  exchangeName: ''
                 }
               })
               done()
@@ -360,7 +361,8 @@ describe('request', function () {
                 timeout: ctx.opts.timeout,
                 sendOpts: ctx.opts.sendOpts,
                 queueOpts: put(ctx.opts.queueOpts, {exclusive: true}),
-                consumeOpts: put(ctx.opts.consumeOpts, {noAck: true})
+                consumeOpts: put(ctx.opts.consumeOpts, {noAck: true}),
+                exchangeName: ''
               }
             })
             done()
@@ -391,7 +393,8 @@ describe('request', function () {
                   timeout: ctx.opts.timeout,
                   sendOpts: ctx.opts.sendOpts,
                   queueOpts: put(ctx.opts.queueOpts, {exclusive: true}),
-                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true})
+                  consumeOpts: put(ctx.opts.consumeOpts, {noAck: true}),
+                  exchangeName: ''
                 }
               })
               done()


### PR DESCRIPTION
Currently the library only allows to make RPC calls to consumers that are bound to the default exchange. This is not the case for use, so we can really use an option to send to other exchanges than default.